### PR TITLE
Add tabindex for the main form

### DIFF
--- a/chrome_extension/main.html
+++ b/chrome_extension/main.html
@@ -20,7 +20,7 @@
 
     <fieldset class="fieldLine fromTop">
         <img src="height-from-top.svg">
-        <input type="text" id="baselinerTop" class="fieldInput">
+        <input type="text" id="baselinerTop" class="fieldInput" tabindex="1">
         <label for="baselinerTop">px</label>
         <div class="arrowsContainer">
             <input type="button" id="topUp" class="arrowUp"">
@@ -31,7 +31,7 @@
 
     <fieldset class="fieldLine fromTop">
         <img src="line-height.svg">
-        <input type="text" id="baselinerValue" class="fieldInput">
+        <input type="text" id="baselinerValue" class="fieldInput" tabindex="2">
         <label for="baselinerValue">px</label>
         <div class="arrowsContainer">
             <input type="button" id="baseUp" class="arrowUp"">
@@ -60,8 +60,8 @@
 
 </section>
 
-<button id="btnApplyBaseliner" class="button">Apply</button>
-<button id="btnRemoveBaseliner" class="button">Remove</button>
+<button id="btnApplyBaseliner" class="button" tabindex="3">Apply</button>
+<button id="btnRemoveBaseliner" class="button" tabindex="4">Remove</button>
 
 <script type="text/javascript" src="jsColorPicker.min.js"></script>
 <script src="main.js"></script>


### PR DESCRIPTION
Hi,
Thanks for the great tool.

Tuning the grid requires switching between the line-height
and offset from the top of the screen.

Since the keyboard up/down arrows work to adjust the values,
the last step for easy keyboard manipulation is to allow the
tab key to switch the two fields